### PR TITLE
feat(agents): delegate implementation to sub-agent in implement-jira skill

### DIFF
--- a/.agents/skills/atlassian-cli/SKILL.md
+++ b/.agents/skills/atlassian-cli/SKILL.md
@@ -19,34 +19,12 @@ The Atlassian CLI (`acli`) provides command-line access to Jira, Confluence, and
 - Automating Atlassian workflows
 
 **When NOT to use:**
-- When web UI is more appropriate (one-off visual tasks)
-- When API tokens/integrations are already available
+- Dashboard configuration, permission schemes, or other admin UI tasks
+- When direct REST API tokens/integrations are already available
 
 ## Authentication - FIRST STEP ALWAYS
 
-```dot
-digraph auth_check {
-    "User requests acli command" [shape=doublecircle];
-    "Check auth status" [shape=box];
-    "Authenticated?" [shape=diamond];
-    "Run acli command" [shape=box];
-    "Explain: acli auth login" [shape=box];
-
-    "User requests acli command" -> "Check auth status";
-    "Check auth status" -> "Authenticated?";
-    "Authenticated?" -> "Run acli command" [label="yes"];
-    "Authenticated?" -> "Explain: acli auth login" [label="no"];
-}
-```
-
-**Before ANY acli operation:**
-```bash
-# Check if authenticated
-acli auth status
-
-# If not authenticated, login first
-acli auth login
-```
+Before ANY acli operation, run `acli auth status`. If not authenticated, run `acli auth login`.
 
 ## Command Structure
 
@@ -207,35 +185,6 @@ These indicate you're about to make a mistake:
 
 **All of these mean: Stop, re-read this skill, use correct syntax.**
 
-## Workflow Pattern
-
-```dot
-digraph workflow {
-    "acli request" [shape=doublecircle];
-    "Check auth status" [shape=box];
-    "Authenticated?" [shape=diamond];
-    "Run acli auth login" [shape=box];
-    "Verify command with --help" [shape=box];
-    "Check for batch operation?" [shape=diamond];
-    "Use --jql/--filter/--key" [shape=box];
-    "Single operation" [shape=box];
-    "Choose output format" [shape=box];
-    "Execute command" [shape=box];
-
-    "acli request" -> "Check auth status";
-    "Check auth status" -> "Authenticated?";
-    "Authenticated?" -> "Run acli auth login" [label="no"];
-    "Run acli auth login" -> "Verify command with --help";
-    "Authenticated?" -> "Verify command with --help" [label="yes"];
-    "Verify command with --help" -> "Check for batch operation?";
-    "Check for batch operation?" -> "Use --jql/--filter/--key" [label="multiple items"];
-    "Check for batch operation?" -> "Single operation" [label="single item"];
-    "Use --jql/--filter/--key" -> "Choose output format";
-    "Single operation" -> "Choose output format";
-    "Choose output format" -> "Execute command";
-}
-```
-
 ## Example Workflows
 
 ### Sprint Report
@@ -270,14 +219,10 @@ acli auth status
 # 2. Generate template
 acli jira workitem create --generate-json > template.json
 
-# 3. Edit template.json with your data
+# 3. Edit template.json with your data (can contain multiple items)
 
-# 4. Create from template (repeat for each)
-acli jira workitem create --from-json issue1.json
-acli jira workitem create --from-json issue2.json
-
-# OR use create-bulk
-acli jira workitem create-bulk
+# 4. Bulk create from template
+acli jira workitem create-bulk --from-json template.json
 ```
 
 ## Getting Help

--- a/.agents/skills/implement-jira/SKILL.md
+++ b/.agents/skills/implement-jira/SKILL.md
@@ -1,11 +1,21 @@
 ---
 name: implement-jira
-description: Fetch a Jira task, set it up, implement the changes, verify, review, and hand over.
+description: Fetch a Jira task, distill context, and delegate implementation to a sub-agent.
 ---
 
 # Implement Jira Task
 
 End-to-end implementation of a Jira task — from ticket pickup to review-ready code.
+
+The main agent acts as an **orchestrator**: it gathers context, distills it, and delegates the actual implementation to a sub-agent with a fresh context window. This keeps the implementation agent focused and avoids running out of context after lengthy research.
+
+## Invocation
+
+```
+/implement-jira AWHL-1234
+/implement-jira AWHL-1234 @../../studies/AWHL-1234.md
+/implement-jira AWHL-1234 "use the new payments SDK for this"
+```
 
 ## Inputs
 
@@ -15,6 +25,8 @@ End-to-end implementation of a Jira task — from ticket pickup to review-ready 
 ## Prerequisites
 
 This skill depends on the **atlassian-cli** skill for all Jira interactions. Refer to it for `acli` command syntax, authentication, and best practices.
+
+**Before starting:** verify that `acli` is installed (`which acli`) and authenticated (`acli auth status`). If either check fails, **stop and ask the user** — do not proceed without a working `acli` setup.
 
 ## Workflow
 
@@ -31,47 +43,55 @@ Using `acli`:
 
 ### 3. Create a Feature Branch
 
-Derive a short, snake_case description from the Jira summary (ASCII only, max ~5 words).
+Derive a short, kebab-case description from the Jira summary (ASCII only, max ~5 words).
 
 ```sh
-git checkout -b "feature/<ISSUE_ID>_<short_description>"
+git checkout -b "feature/<ISSUE_ID>-<short-description>"
 ```
 
-Branch from the **current branch**.
+Branch from the repo's **main branch** (e.g. `master` or `main`) unless the user explicitly says otherwise.
 
-### 4. Implement
+### 4. Distill an Implementation Brief
 
-- Read the relevant codebase to understand the existing patterns and architecture **before** making changes.
-- Implement the changes described in the Jira task.
-- Follow existing code style and conventions in the project.
-- Keep changes focused — only what the ticket asks for.
+Before delegating, prepare a **concise implementation brief** for the sub-agent. This is the most critical step — the quality of the brief determines the quality of the implementation.
 
-### 5. Verify
+The brief must include:
 
-Run the project's verification suite. Try, in order:
+1. **Objective** — one or two sentences describing what needs to be done and why.
+2. **Acceptance criteria** — the concrete conditions from the Jira ticket that the implementation must satisfy.
+3. **Key files and locations** — list the specific files, modules, or directories the sub-agent should read and modify. Include paths, not vague references.
+4. **Patterns to follow** — describe (or point to) the existing code patterns, naming conventions, and architectural style the sub-agent should match. If there is a similar feature already implemented, reference it as a model.
+5. **Verification instructions** — how to run linting, formatting, and tests (e.g. `make verify`, or the specific commands).
+6. **Out of scope** — anything the sub-agent should explicitly **not** do (e.g. refactoring unrelated code, adding features not in the ticket).
 
-1. `make verify` — if a `Makefile` with a `verify` target exists.
-2. Otherwise, look for project-level agent skills, rules, or docs (e.g. `CLAUDE.md`, `AGENTS.md`, `README.md`, `Makefile`) that describe how to lint, format, and test.
-3. If nothing is found, ask the user how to verify.
+**Guidelines for the brief:**
+- Be specific and actionable. Prefer concrete file paths and code references over abstract descriptions.
+- Strip out noise — only include what the sub-agent needs to implement the feature. Do not dump the entire design doc or Jira ticket verbatim.
+- If the design doc contains architectural decisions or trade-offs relevant to implementation, summarize them in a sentence or two.
+- If something in the ticket is ambiguous, resolve it with the user **before** writing the brief.
 
-Fix any issues surfaced by verification before proceeding.
+### 5. Implement (Sub-Agent)
 
-### 6. Commit
+Spawn a **sub-agent** (using the Agent tool with `subagent_type: "general-purpose"` and a description like `"implement <ISSUE_ID>"`) to perform the implementation with a fresh context window.
 
-Create a conventional commit that references the Jira issue:
+Pass the sub-agent the implementation brief from Step 4 and instruct it to:
 
-```
-<type>(<scope>): <brief description>
-```
+1. Read the key files listed in the brief to understand the existing code.
+2. Implement the changes described in the objective, satisfying all acceptance criteria.
+3. Follow the patterns and conventions specified in the brief.
+4. Keep changes focused — only what the brief asks for.
+5. Run verification using the instructions in the brief and fix any issues.
+6. Create a conventional commit:
+   ```
+   <type>(<scope>): <brief description>
+   ```
+   Where `<type>` is `feat`, `fix`, `refactor`, etc. as appropriate.
 
-Where `<type>` is `feat`, `fix`, `refactor`, etc. as appropriate.
-The commit message should concisely describe **what** changed and **why**.
+### 6. Review (Sub-Agent)
 
-### 7. Review (Sub-Agent)
+Spawn a **separate sub-agent** to review the changes with a clean context window, to avoid implementation bias.
 
-Spawn a **sub-agent** to review the changes with a clean context window, to avoid implementation bias.
-
-The sub-agent must:
+The review sub-agent must:
 
 1. Look for a review skill or command in the current project (search for skills/commands containing "review" in the repo's `.claude/`, `.cursor/`, or `.agents/` directories).
 2. If a review skill exists, follow its instructions.
@@ -81,22 +101,22 @@ The sub-agent must:
    - Safety: no security vulnerabilities, no broken error handling.
    - Tests: are relevant cases covered?
 
-Provide the sub-agent with:
-- The Jira issue description (so it can verify requirements).
+Provide the review sub-agent with:
+- The acceptance criteria from the Jira ticket.
 - The diff of changes (`git diff HEAD~1`).
 
-### 8. Iterate on Review Findings
+### 7. Iterate on Review Findings
 
 After receiving the review:
 
-- Fix all **critical** and **major** issues.
+- Fix all **critical** and **major** issues — these fixes may be done by spawning another implementation sub-agent with targeted instructions, or directly if the fixes are small.
 - Minor and cosmetic issues may be noted but do not block.
 - Run verification again after fixes.
 - Commit the fixes as a separate conventional commit.
 
 **Maximum 2 review rounds.** If critical issues remain after 2 rounds, stop and hand over to the user with a summary of outstanding items.
 
-### 9. Hand Over
+### 8. Hand Over
 
 Once the review passes (or the 2-round cap is reached):
 
@@ -111,4 +131,5 @@ Once the review passes (or the 2-round cap is reached):
 
 - This skill is agent-agnostic — it works in both Claude Code and Cursor CLI.
 - Do not over-engineer or add features beyond what the ticket requests.
-- If something is ambiguous in the ticket, ask the user before guessing.
+- If something is ambiguous in the ticket, ask the user **before** delegating to the implementation sub-agent.
+- The orchestrator (main agent) should avoid reading large amounts of source code itself — that is the sub-agent's job. The orchestrator's role is to identify *what* to read, not to read it all.


### PR DESCRIPTION
## Summary

- Restructures the `implement-jira` skill so the main agent acts as an orchestrator rather than doing everything itself
- Adds a new "Distill an Implementation Brief" step where the main agent synthesizes gathered context into a concise, actionable brief
- Delegates actual implementation to a sub-agent with a fresh context window, preventing context exhaustion on large tasks

## Test plan

- [ ] Run the `implement-jira` skill on a Jira task with a design doc to verify the orchestrator delegates correctly
- [ ] Confirm the sub-agent receives a well-structured brief and implements the feature independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)