### PR TITLE
bugfix(tmux): only auto-exec tmux when stdout is a TTY

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -18,6 +18,6 @@ eval $(/opt/homebrew/bin/brew shellenv)
 # Shell will launch tmux on start up. It will only do so if tmux exists on the
 # system, if we are on an interactive shell, and if tmux is not trying to run
 # within itself.
-if command -v tmux &> /dev/null && [ -n "$PS1" ] && [[ ! "$TERM" =~ screen ]] && [[ ! "$TERM" =~ tmux ]] && [ -z "$TMUX" ]; then
+if command -v tmux &> /dev/null && [ -n "$PS1" ] && [[ ! "$TERM" =~ screen ]] && [[ ! "$TERM" =~ tmux ]] && [ -z "$TMUX" ] && [ -t 1 ]; then
   exec tmux
 fi


### PR DESCRIPTION
## Summary
- Guards the auto-`exec tmux` block in `.bashrc` with `[ -t 1 ]` so it only runs when stdout is an actual terminal.

## Why
In an interactive but non-TTY bash (e.g. cloud-hosted Claude Code agents that spawn `bash -i`), `PS1` is set and the existing guards pass, so `exec tmux` runs. tmux can't open a terminal, fails with `open terminal failed: not a terminal`, and because of `exec` the shell dies with it — every subsequent command in that session fails before it runs.

Adding `[ -t 1 ]` keeps the local interactive behaviour identical (TTY is present), but skips the auto-launch in non-TTY contexts where it can't possibly work.

## Test plan
- [x] Local interactive shell still auto-execs into tmux on launch.
- [x] Non-TTY bash session (cloud agent) no longer dies during `.bashrc` sourcing — commands run normally.